### PR TITLE
Fall back to lower LOD levels in assembleImage

### DIFF
--- a/src/rocky/ImageLayer.cpp
+++ b/src/rocky/ImageLayer.cpp
@@ -169,7 +169,14 @@ ImageLayer::assembleImage(const TileKey& key, const IOOptions& io) const
 
     if (key.levelOfDetail() > 0u)
     {
-        key.getIntersectingKeys(profile(), intersectingKeys);
+        TileKey currentKey = key;
+        while (currentKey.levelOfDetail() > 0u)
+        {
+            std::vector<TileKey> intermediate;
+            currentKey.getIntersectingKeys(profile(), intermediate);
+            intersectingKeys.insert(intersectingKeys.end(), intermediate.begin(), intermediate.end());
+            currentKey.makeParent();
+        }
     }
 
     else


### PR DESCRIPTION
When the imagery and map tiles are using a different profile to the tile key, they'll need reprojecting, and if any image is unavailable, it can affect several tiles. That also means there can be tiles which are partially covered by tiles at a particular LOD level.

Without this change, only one LOD level is tried, and if a tile is partially covered, it'll get used, but leave gaps in the map. With this change, those gaps will be filled with lower-quality imagery from other LOD levels.

## Before
![image](https://github.com/pelicanmapping/rocky/assets/8485112/591b9c51-f732-4d9a-95d1-e9d77045697f)

## After
![image](https://github.com/pelicanmapping/rocky/assets/8485112/4171bb0d-122d-45be-9096-4364851ae6c8)

To reproduce the problem, you can use this map (which was originally a `.earth` file):
```json
{
    "layers": [
        {
            "name": "ReadyMap 15m Imagery",
            "type": "TMSImage",
            "uri": "http://readymap.org/readymap/tiles/1.0.0/7/"
        },
        {
            "name": "ReadyMap 90m Elevation",
            "type": "TMSElevation",
            "uri": "http://readymap.org/readymap/tiles/1.0.0/116/",
            "vdatum": "egm96"
        },
        {
            "time": "1.5",
            "type": "xi:include",
            "viewpoint": {}
        }
    ],
    "options": {
        "cache": {},
        "profile": {}
    },
    "profile": {
        "extent": {
            "srs": "+proj=utm +zone=30 +datum=WGS84 +units=m +no_defs",
            "xmax": 750000.0,
            "xmin": 650000.0,
            "ymax": 4400000.0,
            "ymin": 4300000.0
        },
        "tx": 1,
        "ty": 1
    }
}
```