### PR TITLE
Terrain-relative height proof of concept

### DIFF
--- a/src/apps/rdemo/rdemo.cpp
+++ b/src/apps/rdemo/rdemo.cpp
@@ -77,6 +77,7 @@ std::vector<Demo> demos =
         Demo{ "Line - relative", Demo_Line_Relative },
         Demo{ "Mesh - absolute", Demo_Mesh_Absolute },
         Demo{ "Mesh - relative", Demo_Mesh_Relative },
+        Demo{ "Mesh - terrain-relative", Demo_Mesh_TerrainRelative },
         Demo{ "Icon", Demo_Icon },
         Demo{ "User Model", Demo_Model }
     } },

--- a/src/rocky/EntityPosition.cpp
+++ b/src/rocky/EntityPosition.cpp
@@ -1,0 +1,83 @@
+#include "EntityPosition.h"
+#include "Math.h"
+#include "Utils.h"
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::util;
+
+#undef  LC
+#define LC "[EntityPosition] "
+
+EntityPosition EntityPosition::INVALID;
+
+EntityPosition::EntityPosition()
+{
+    //nop
+}
+
+EntityPosition&
+EntityPosition::operator=(EntityPosition&& rhs)
+{
+    basePosition = rhs.basePosition;
+    altitude = rhs.altitude;
+    rhs.basePosition = { }; // invalidate rhs
+    return *this;
+}
+
+EntityPosition::EntityPosition(const GeoPoint& in_basePosition, double in_altitude) :
+    basePosition(in_basePosition),
+    altitude(in_altitude)
+{
+    //nop
+}
+
+bool
+EntityPosition::transform(const SRS& outSRS, EntityPosition& output) const
+{
+    if (valid() && outSRS.valid())
+    {
+        GeoPoint outBasePosition;
+        if (basePosition.transform(outSRS, outBasePosition))
+        {
+            output = EntityPosition(outBasePosition, altitude);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool
+EntityPosition::transformInPlace(const SRS& to_srs)
+{
+    if (valid() && to_srs.valid())
+    {
+        if (basePosition.transformInPlace(to_srs))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+#include "json.h"
+
+namespace ROCKY_NAMESPACE
+{
+    void to_json(json& j, const EntityPosition& obj) {
+        if (obj.valid()) {
+            j = json::object();
+            set(j, "basePosition", obj.basePosition);
+            set(j, "altitude", obj.altitude);
+        }
+    }
+
+    void from_json(const json& j, EntityPosition& obj) {
+        GeoPoint basePosition;
+        double altitude = 0;
+
+        get_to(j, "basePosition", basePosition);
+        get_to(j, "altitude", altitude);
+
+        obj = EntityPosition(basePosition, altitude);
+    }
+}

--- a/src/rocky/EntityPosition.h
+++ b/src/rocky/EntityPosition.h
@@ -1,0 +1,72 @@
+/**
+ * rocky c++
+ * Copyright 2024 Pelican Mapping
+ * MIT License
+ */
+#pragma once
+
+#include <rocky/GeoPoint.h>
+
+namespace ROCKY_NAMESPACE
+{
+    /**
+     * A georeferenced 3D point with terrain-relative altitude
+     */
+    class ROCKY_EXPORT EntityPosition
+    {
+    public:
+        GeoPoint basePosition;
+        double altitude;
+
+        //! Constructs an empty (and invalid) EntityPosition.
+        EntityPosition();
+
+        //! Constructs a EntityPosition
+        EntityPosition(const GeoPoint& srs, double altitude);
+
+        //! Destruct
+        ~EntityPosition() { }
+
+        //! Transforms this EntityPosition into another SRS and puts the
+        //! output in the "output"
+        //! @return true upon success, false upon failure
+        bool transform(const SRS& outSRS, EntityPosition& output) const;
+
+        //! Transforms this point in place to another SRS
+        bool transformInPlace(const SRS& srs);
+
+        bool operator == (const EntityPosition& rhs) const {
+            return basePosition == rhs.basePosition && altitude == rhs.altitude;
+        }
+
+        bool operator != (const EntityPosition& rhs) const {
+            return !operator==(rhs);
+        }
+
+        //! Does this object contain a valid geo point?
+        bool valid() const {
+            return basePosition.valid();
+        }
+
+    public:
+        static EntityPosition INVALID;
+
+        // copy/move ops
+        EntityPosition(const EntityPosition& rhs) = default;
+        EntityPosition& operator=(const EntityPosition& rhs) = default;
+        EntityPosition(EntityPosition&& rhs) { *this = rhs; }
+        EntityPosition& operator=(EntityPosition&& rhs);
+    };
+
+
+    /**
+    * Base class for any object that has a position on a Map.
+    */
+    class TerrainRelativePositionedObject
+    {
+    public:
+        //! Center position of the object
+        virtual const EntityPosition& objectPosition() const = 0;
+    };
+
+}

--- a/src/rocky/vsg/EntityTransform.cpp
+++ b/src/rocky/vsg/EntityTransform.cpp
@@ -1,0 +1,127 @@
+/**
+ * rocky c++
+ * Copyright 2024 Pelican Mapping
+ * MIT License
+ */
+#include "EntityTransform.h"
+#include "engine/TerrainEngine.h"
+#include "engine/Utils.h"
+#include <rocky/Horizon.h>
+
+using namespace ROCKY_NAMESPACE;
+
+EntityTransform::EntityTransform()
+{
+    // force creation of the first viewlocal data structure
+    _viewlocal[0].dirty = true;
+}
+
+void
+EntityTransform::setPosition(const EntityPosition& position_)
+{
+    if (position != position_)
+    {
+        position = position_;
+        dirty();
+    }
+}
+
+void
+EntityTransform::dirty()
+{
+    for (auto& view : _viewlocal)
+        view.dirty = true;
+}
+
+void
+EntityTransform::accept(vsg::RecordTraversal& record) const
+{
+    // traverse the transform
+    if (push(record, vsg::dmat4(1.0)))
+    {
+        vsg::Group::accept(record);
+        pop(record);
+    }
+}
+
+bool
+EntityTransform::push(vsg::RecordTraversal& record, const vsg::dmat4& local_matrix) const
+{
+    auto state = record.getState();
+
+    // update the view-local data if necessary:
+    auto& view = _viewlocal[record.getState()->_commandBuffer->viewID];
+    if (view.dirty || local_matrix != view.local_matrix)
+    {
+        GeoPoint wgs84Point;
+        position.basePosition.transform(SRS::WGS84, wgs84Point);
+        wgs84Point.z = position.altitude;
+        TerrainEngine* terrainEngine;
+        if (record.getValue("terrainengine", terrainEngine))
+        {
+            const auto& tilePager = terrainEngine->tiles;
+            unsigned bestLod = 0;
+            vsg::ref_ptr<TerrainTileNode> tileNode;
+            for (const auto& [key, entry] : tilePager._tiles)
+            {
+                if (key.extent().contains(position.basePosition) && bestLod < key.levelOfDetail() && entry._tile->dataLoader.available())
+                {
+                    bestLod = key.levelOfDetail();
+                    tileNode = entry._tile;
+                }
+            }
+            if (tileNode)
+            {
+                GeoPoint heightfieldPoint;
+                // pre-transform position in case Z matters e.g. ECEF
+                if (position.basePosition.transform(tileNode->dataLoader.value().elevation.heightfield.srs(), heightfieldPoint))
+                {
+                    auto height = tileNode->dataLoader.value().elevation.heightfield.heightAtLocation(heightfieldPoint.x, heightfieldPoint.y);
+                    Log()->info("Read height {:f}", height);
+                    // todo: apply heighfield range
+                    wgs84Point.z += height;
+                }
+            }
+        }
+        SRS worldSRS;
+        if (record.getValue("worldsrs", worldSRS))
+        {
+            if (wgs84Point.transform(worldSRS, view.worldPos))
+            {
+                view.matrix =
+                    to_vsg(worldSRS.localToWorldMatrix(glm::dvec3(view.worldPos.x, view.worldPos.y, view.worldPos.z))) *
+                    local_matrix;
+            }
+        }
+
+        view.local_matrix = local_matrix;
+        view.dirty = false;
+    }
+
+    // horizon cull, if active:
+    if (horizonCulling)
+    {
+        std::shared_ptr<Horizon> horizon;
+        if (state->getValue("horizon", horizon))
+        {
+            if (!horizon->isVisible(view.matrix[3][0], view.matrix[3][1], view.matrix[3][2], bound.radius))
+                return false;
+        }
+    }
+
+    // replicates RecordTraversal::accept(MatrixTransform&):
+    state->modelviewMatrixStack.push(state->modelviewMatrixStack.top() * view.matrix);
+    state->dirty = true;
+    state->pushFrustum();
+
+    return true;
+}
+
+void
+EntityTransform::pop(vsg::RecordTraversal& record) const
+{
+    auto state = record.getState();
+    state->popFrustum();
+    state->modelviewMatrixStack.pop();
+    state->dirty = true;
+}

--- a/src/rocky/vsg/EntityTransform.h
+++ b/src/rocky/vsg/EntityTransform.h
@@ -1,0 +1,86 @@
+/**
+ * rocky c++
+ * Copyright 2024 Pelican Mapping
+ * MIT License
+ */
+#pragma once
+
+#include <rocky/vsg/Common.h>
+#include <rocky/vsg/engine/ViewLocal.h>
+#include <rocky/EntityPosition.h>
+#include <vsg/nodes/CullGroup.h>
+#include <vsg/nodes/Transform.h>
+
+namespace ROCKY_NAMESPACE
+{
+    template<class T>
+    struct TerrainRelativePositionedObjectAdapter : public TerrainRelativePositionedObject
+    {
+        vsg::ref_ptr<T> object;
+        virtual const EntityPosition& objectPosition() const {
+            return object->position;
+        }
+        static std::shared_ptr<TerrainRelativePositionedObjectAdapter<T>> create(vsg::ref_ptr<T> object_) {
+            auto r = std::make_shared< TerrainRelativePositionedObjectAdapter<T>>();
+            r->object = object_;
+            return r;
+        }
+    };
+    /**
+     * Transform node that accepts geospatial coordinates and creates
+     * a local ENU (X=east, Y=north, Z=up) coordinate frame for its children
+     * that is tangent to the earth at the transform's geo position on the 
+     * terrain surface.
+     */
+    class ROCKY_EXPORT EntityTransform :
+        public vsg::Inherit<vsg::Group, EntityTransform>,
+        TerrainRelativePositionedObject
+    {
+    public:
+        EntityPosition position;
+
+        //! Sphere for horizon culling
+        vsg::dsphere bound = { };
+
+        //! whether horizon culling is active
+        bool horizonCulling = true;
+
+    public:
+        //! Construct an invalid EntityTransform
+        EntityTransform();
+
+        //! Call this is you change position directly.
+        void dirty();
+
+        //! Same as changing position and calling dirty().
+        void setPosition(const EntityPosition& p);
+
+    public: // TerrainRelativePositionedObject interface
+
+        const EntityPosition& objectPosition() const override {
+            return position;
+        }
+
+    public:
+
+        EntityTransform(const EntityTransform& rhs) = delete;
+
+        void accept(vsg::RecordTraversal&) const override;
+
+        bool push(vsg::RecordTraversal&, const vsg::dmat4& m) const;
+
+        void pop(vsg::RecordTraversal&) const;
+
+    protected:
+
+
+        struct Data {
+            bool dirty = true;
+            GeoPoint worldPos;
+            vsg::dmat4 matrix;
+            vsg::dmat4 local_matrix;
+        };
+        util::ViewLocal<Data> _viewlocal;
+
+    };
+} // namespace

--- a/src/rocky/vsg/MapNode.cpp
+++ b/src/rocky/vsg/MapNode.cpp
@@ -180,5 +180,7 @@ MapNode::accept(vsg::RecordTraversal& rv) const
 
     rv.setValue("worldsrs", worldSRS());
 
+    rv.setValue("terrainengine", terrain->engine.get());
+
     Inherit::accept(rv);
 }


### PR DESCRIPTION
This isn't really intended to be merged - I've basically taken a stab at what was discussed here https://github.com/pelicanmapping/rocky/discussions/33 and would like a general idea of how horrifying the implementation is from someone who has a better idea of how things are supposed to work.

I used the class name suggested in the discussion, but it's probably not a good choice as it might get confusing with there also being an ECS that also has entities.

It should probably automatically dirty itself when new LOD is streamed in or out as otherwise a feature that is only represented at certain LOD levels may lead to a node ending up underground or floating. I've not implemented this yet, though.