### PR TITLE
Add support for Bing and Azure maps

### DIFF
--- a/.github/workflows/ci-windows-minimal.yml
+++ b/.github/workflows/ci-windows-minimal.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{ runner.workspace }}/build
-      run: cmake $GITHUB_WORKSPACE -DWIN32_USE_MP=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DROCKY_SUPPORTS_GDAL=OFF -DROCKY_SUPPORTS_MBTILES=OFF -DCMAKE_TOOLCHAIN_FILE=${{ matrix.VCPKG_WORKSPACE }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_BUILD_TYPE=$BUILD_TYPE -DVCPKG_MANIFEST_DIR=$GITHUB_WORKSPACE/vcpkg
+      run: cmake $GITHUB_WORKSPACE -DWIN32_USE_MP=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DROCKY_SUPPORTS_GDAL=OFF -DROCKY_SUPPORTS_MBTILES=OFF -DROCKY_SUPPORTS_AZURE=OFF -DROCKY_SUPPORTS_BING=OFF -DCMAKE_TOOLCHAIN_FILE=${{ matrix.VCPKG_WORKSPACE }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_BUILD_TYPE=$BUILD_TYPE -DVCPKG_MANIFEST_DIR=$GITHUB_WORKSPACE/vcpkg
 
     - name: 'Upload cmake configure log artifact'
       uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ option(ROCKY_SUPPORTS_HTTPS "Support HTTPS (requires openssl)" ON)
 option(ROCKY_SUPPORTS_TMS "Support OSGeo TileMapService" ON)
 option(ROCKY_SUPPORTS_GDAL "Support GeoTIFF, WMS, WMTS, and other GDAL formats (requires gdal)" ON)
 option(ROCKY_SUPPORTS_MBTILES "Support MBTiles databases with extended spatial profile support (requires sqlite3, zlib)" ON)
+option(ROCKY_SUPPORTS_AZURE "Support Azure Maps" ON)
+option(ROCKY_SUPPORTS_BING "Support Bing Maps" ON)
 option(ROCKY_SUPPORTS_IMGUI "Build ImGui demos" ON)
 option(ROCKY_SUPPORTS_QT "Build Qt demos" OFF)
 
@@ -91,6 +93,14 @@ if (ROCKY_SUPPORTS_MBTILES)
     set(BUILD_WITH_SQLITE3 ON)
     set(BUILD_WITH_ZLIB ON)
     set(ROCKY_HAS_MBTILES ON)
+endif()
+
+if (ROCKY_SUPPORTS_AZURE)
+    set(ROCKY_HAS_AZURE ON)
+endif()
+
+if (ROCKY_SUPPORTS_BING)
+    set(ROCKY_HAS_BING ON)
 endif()
 
 if (ROCKY_SUPPORTS_TMS)

--- a/src/rocky/Azure.cpp
+++ b/src/rocky/Azure.cpp
@@ -1,0 +1,12 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#include "Azure.h"
+#ifdef ROCKY_HAS_AZURE
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::Azure;
+
+#endif // ROCKY_HAS_AZURE

--- a/src/rocky/Azure.h
+++ b/src/rocky/Azure.h
@@ -1,0 +1,32 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#pragma once
+
+#include <rocky/Version.h>
+#ifdef ROCKY_HAS_AZURE
+
+#include <rocky/Common.h>
+#include <rocky/optional.h>
+#include <rocky/URI.h>
+
+namespace ROCKY_NAMESPACE
+{
+    namespace Azure
+    {
+        struct Options
+        {
+            optional<std::string> subscriptionKey;
+            optional<std::string> tilesetId = { "microsoft.base.darkgrey" };
+            optional<URI> mapTileApiUrl = { "https://atlas.microsoft.com/map/tile" };
+        };
+    }
+}
+
+#else // if !ROCKY_HAS_AZURE
+  #ifndef ROCKY_BUILDING_SDK
+    #error Azure support is not enabled in Rocky.
+  #endif
+#endif // ROCKY_HAS_AZURE

--- a/src/rocky/AzureImageLayer.cpp
+++ b/src/rocky/AzureImageLayer.cpp
@@ -1,0 +1,115 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#include "AzureImageLayer.h"
+#ifdef ROCKY_HAS_AZURE
+
+#include "Instance.h"
+#include "json.h"
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::Azure;
+
+#undef LC
+#define LC "[Azure] "
+
+ROCKY_ADD_OBJECT_FACTORY(AzureImage,
+    [](const JSON& conf) { return AzureImageLayer::create(conf); })
+
+AzureImageLayer::AzureImageLayer() :
+    super()
+{
+    construct(JSON());
+}
+
+AzureImageLayer::AzureImageLayer(const JSON& conf) :
+    super(conf)
+{
+    construct(conf);
+}
+
+void
+AzureImageLayer::construct(const JSON& conf)
+{
+    setConfigKey("AzureImage");
+    const auto j = parse_json(conf);
+    get_to(j, "subscription_key", subscriptionKey);
+    get_to(j, "tileset_id", tilesetId);
+    get_to(j, "map_tile_api_url", mapTileApiUrl);
+}
+
+JSON
+AzureImageLayer::to_json() const
+{
+    auto j = parse_json(super::to_json());
+    set(j, "subscription_key", subscriptionKey);
+    set(j, "tileset_id", tilesetId);
+    set(j, "map_tile_api_url", mapTileApiUrl);
+    return j.dump();
+}
+
+Status
+AzureImageLayer::openImplementation(const IOOptions& io)
+{
+    Status parent = super::openImplementation(io);
+    if (parent.failed())
+        return parent;
+
+    _profile = Profile::SPHERICAL_MERCATOR;
+    setDataExtents({ _profile->extent() });
+
+    ROCKY_TODO("When disk cache is implemented, disable it here (or come up with a mechanism to ensure it only lasts six months/the period specified in the response header) to comply with ToS.");
+
+    ROCKY_TODO("update attribution - it's a separate API call and depends on the visible region and zoom level, or can be queried for individual tiles, or there's an API to get a big JSON object with strings for each region of the world all at once");
+
+    return StatusOK;
+}
+
+void
+AzureImageLayer::closeImplementation()
+{
+    super::closeImplementation();
+}
+
+Result<GeoImage>
+AzureImageLayer::createImageImplementation(const TileKey& key, const IOOptions& io) const
+{
+    ROCKY_PROFILE_FUNCTION();
+
+    auto zoom = key.levelOfDetail();
+    auto x = key.tileX();
+    auto y = key.tileY();
+
+    std::stringstream query;
+    query << "?api-version=2024-04-01";
+    query << "&tilesetId=" << tilesetId.value();
+    query << "&zoom=" << zoom << "&x=" << x << "&y=" << y;
+    // can be 256 or 512 - possibly worth making configurable
+    query << "&tileSize=512";
+    // can also authenticate with headers set in mapTileApiUrl
+    if (subscriptionKey.has_value())
+        query << "&subscription-key=" << subscriptionKey.value();
+
+    URI imageURI(mapTileApiUrl->full() + query.str(), mapTileApiUrl->context());
+
+    auto fetch = imageURI.read(io);
+    if (fetch.status.failed())
+        return fetch.status;
+
+    std::istringstream buf(fetch->data);
+    auto image_rr = io.services.readImageFromStream(buf, fetch->contentType, io);
+
+    if (image_rr.status.failed())
+        return image_rr.status;
+
+    shared_ptr<Image> image = image_rr.value;
+
+    if (image)
+        return GeoImage(image, key.extent());
+    else
+        return StatusError;
+}
+
+#endif // ROCKY_HAS_AZURE

--- a/src/rocky/AzureImageLayer.h
+++ b/src/rocky/AzureImageLayer.h
@@ -1,0 +1,51 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#pragma once
+#include <rocky/Azure.h>
+#ifdef ROCKY_HAS_AZURE
+
+#include <rocky/ImageLayer.h>
+#include <rocky/URI.h>
+
+namespace ROCKY_NAMESPACE
+{
+    /**
+     * Image layer reading from Microsoft's Azure Maps API
+     */
+    class ROCKY_EXPORT AzureImageLayer : public Inherit<ImageLayer, AzureImageLayer>, public Azure::Options
+    {
+    public:
+        //! Construct an empty Azure layer
+        AzureImageLayer();
+        AzureImageLayer(const JSON&);
+
+        //! Destructor
+        virtual ~AzureImageLayer() { }
+
+        //! serialize
+        JSON to_json() const override;
+
+    protected: // Layer
+
+        Status openImplementation(const IOOptions& io) override;
+
+        void closeImplementation() override;
+
+        //! Creates a raster image for the given tile key
+        Result<GeoImage> createImageImplementation(const TileKey& key, const IOOptions& io) const override;
+
+    private:
+
+        void construct(const JSON&);
+    };
+}
+
+
+#else // if !ROCKY_HAS_AZURE
+#ifndef ROCKY_BUILDING_SDK
+#error Azure support is not enabled in Rocky.
+#endif
+#endif // ROCKY_HAS_AZURE

--- a/src/rocky/Bing.cpp
+++ b/src/rocky/Bing.cpp
@@ -1,0 +1,12 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#include "Bing.h"
+#ifdef ROCKY_HAS_BING
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::Bing;
+
+#endif // ROCKY_HAS_BING

--- a/src/rocky/Bing.h
+++ b/src/rocky/Bing.h
@@ -1,0 +1,38 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#pragma once
+
+#include <rocky/Version.h>
+#ifdef ROCKY_HAS_BING
+
+#include <rocky/Common.h>
+#include <rocky/optional.h>
+#include <rocky/URI.h>
+
+namespace ROCKY_NAMESPACE
+{
+    namespace Bing
+    {
+        struct ImageLayerOptions
+        {
+            optional<std::string> apiKey;
+            optional<std::string> imagerySet = { "Aerial" };
+            optional<URI> imageryMetadataUrl = { "https://dev.virtualearth.net/REST/v1/Imagery/Metadata" };
+        };
+
+        struct ElevationLayerOptions
+        {
+            optional<std::string> apiKey;
+            optional<URI> url = { "http://dev.virtualearth.net/REST/v1/Elevation/Bounds" };
+        };
+    }
+}
+
+#else // if !ROCKY_HAS_BING
+  #ifndef ROCKY_BUILDING_SDK
+    #error Bing support is not enabled in Rocky.
+  #endif
+#endif // ROCKY_HAS_BING

--- a/src/rocky/BingElevationLayer.cpp
+++ b/src/rocky/BingElevationLayer.cpp
@@ -1,0 +1,117 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#include "BingElevationLayer.h"
+#ifdef ROCKY_HAS_BING
+
+#include "Instance.h"
+#include "json.h"
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::Bing;
+
+#undef LC
+#define LC "[Bing] "
+
+ROCKY_ADD_OBJECT_FACTORY(BingElevation, 
+    [](const JSON& conf) { return BingElevationLayer::create(conf); })
+
+BingElevationLayer::BingElevationLayer() :
+    super()
+{
+    construct(JSON());
+}
+
+BingElevationLayer::BingElevationLayer(const JSON& conf) :
+    super(conf)
+{
+    construct(conf);
+}
+
+void
+BingElevationLayer::construct(const JSON& conf)
+{
+    setConfigKey("BingElevation");
+    const auto j = parse_json(conf);
+    get_to(j, "key", apiKey);
+    get_to(j, "url", url);
+}
+
+JSON
+BingElevationLayer::to_json() const
+{
+    auto j = parse_json(super::to_json());
+    set(j, "key", apiKey);
+    set(j, "url", url);
+    return j.dump();
+}
+
+Status
+BingElevationLayer::openImplementation(const IOOptions& io)
+{
+    Status parent = super::openImplementation(io);
+    if (parent.failed())
+        return parent;
+
+    _profile = Profile::SPHERICAL_MERCATOR;
+
+    ROCKY_TODO("When disk cache is implemented, disable it here as it violates the ToS");
+
+    ROCKY_TODO("Update attribution - it's included in the JSON response, but we don't track which tiles are still visible and only have the data in a const function");
+
+    return StatusOK;
+}
+
+void
+BingElevationLayer::closeImplementation()
+{
+    super::closeImplementation();
+}
+
+Result<GeoHeightfield>
+BingElevationLayer::createHeightfieldImplementation(const TileKey& key, const IOOptions& io) const
+{
+    ROCKY_PROFILE_FUNCTION();
+
+    if (!isOpen())
+        return status();
+
+    GeoExtent latLongExtent = Profile::GLOBAL_GEODETIC.clampAndTransformExtent(key.extent());
+
+    unsigned tileSize = 32;
+    std::stringstream query;
+    query << std::setprecision(12);
+    query << "?bounds=" << latLongExtent.yMin() << "," << latLongExtent.xMin() << "," << latLongExtent.yMax() << "," << latLongExtent.xMax();
+    query << "&rows=" << tileSize;
+    query << "&cols=" << tileSize;
+    query << "&heights=ellipsoid";
+    if (apiKey.has_value())
+        query << "&key=" << apiKey.value();
+
+    URI dataURI(url->full() + query.str(), url->context());
+
+    auto fetch = dataURI.read(io);
+    if (fetch.status.failed())
+        return fetch.status;
+
+    auto json = parse_json(fetch->data);
+    const auto& elevations = json["/resourceSets/0/resources/0/elevations"_json_pointer];
+    if (elevations.empty())
+        return Status("JSON response contained no elevations");
+    if (!elevations.is_array())
+        return Status("JSON response contained unexpected type");
+    if (elevations.size() != tileSize * tileSize)
+        return Status("JSON response contained unexpected number of points");
+
+    auto heightfield = Heightfield::create(tileSize, tileSize);
+    auto jsonItr = elevations.begin();
+    heightfield->forEachHeight([&](float& point) {point = (jsonItr++)->get<float>(); });
+
+    return GeoHeightfield(heightfield, key.extent());
+
+    return StatusError;
+}
+
+#endif // ROCKY_HAS_BING

--- a/src/rocky/BingElevationLayer.h
+++ b/src/rocky/BingElevationLayer.h
@@ -1,0 +1,54 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#pragma once
+#include <rocky/Bing.h>
+
+#ifdef ROCKY_HAS_BING
+
+#include <rocky/ElevationLayer.h>
+#include <rocky/URI.h>
+
+namespace ROCKY_NAMESPACE
+{
+    /**
+     * Elevation layer reading from from Microsoft's Bing Maps API
+     */
+    class ROCKY_EXPORT BingElevationLayer : public Inherit<ElevationLayer, BingElevationLayer>,
+        public Bing::ElevationLayerOptions
+    {
+    public:
+        //! Construct an empty Bing layer
+        BingElevationLayer();
+        BingElevationLayer(const JSON&);
+
+        //! Destructor
+        virtual ~BingElevationLayer() { }
+
+        //! Serialize
+        JSON to_json() const override;
+
+        optional<Encoding> encoding;
+
+    public: // Layer
+
+        Status openImplementation(const IOOptions& io) override;
+
+        void closeImplementation() override;
+
+        //! Creates a raster image for the given tile key
+        Result<GeoHeightfield> createHeightfieldImplementation(const TileKey& key, const IOOptions& io) const override;
+
+
+    private:
+        void construct(const JSON&);
+    };
+}
+
+#else // if !ROCKY_HAS_BING
+#ifndef ROCKY_BUILDING_SDK
+#error Bing support is not enabled in Rocky.
+#endif
+#endif // ROCKY_HAS_BING

--- a/src/rocky/BingImageLayer.cpp
+++ b/src/rocky/BingImageLayer.cpp
@@ -1,0 +1,144 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#include "BingImageLayer.h"
+#ifdef ROCKY_HAS_BING
+
+#include "Instance.h"
+#include "json.h"
+
+using namespace ROCKY_NAMESPACE;
+using namespace ROCKY_NAMESPACE::Bing;
+
+#undef LC
+#define LC "[Bing] "
+
+ROCKY_ADD_OBJECT_FACTORY(BingImage,
+    [](const JSON& conf) { return BingImageLayer::create(conf); })
+
+BingImageLayer::BingImageLayer() :
+    super()
+{
+    construct(JSON());
+}
+
+BingImageLayer::BingImageLayer(const JSON& conf) :
+    super(conf)
+{
+    construct(conf);
+}
+
+void
+BingImageLayer::construct(const JSON& conf)
+{
+    setConfigKey("BingImage");
+    const auto j = parse_json(conf);
+    get_to(j, "key", apiKey);
+    get_to(j, "imagery_set", imagerySet);
+    get_to(j, "imagery_metadata_api_url", imageryMetadataUrl);
+}
+
+JSON
+BingImageLayer::to_json() const
+{
+    auto j = parse_json(super::to_json());
+    set(j, "key", apiKey);
+    set(j, "imagery_set", imagerySet);
+    set(j, "imagery_metadata_api_url", imageryMetadataUrl);
+    return j.dump();
+}
+
+Status
+BingImageLayer::openImplementation(const IOOptions& io)
+{
+    Status parent = super::openImplementation(io);
+    if (parent.failed())
+        return parent;
+
+    _profile = Profile(SRS::SPHERICAL_MERCATOR, Profile::SPHERICAL_MERCATOR.extent().bounds(), 2, 2);
+    setDataExtents({ _profile->extent() });
+
+    _tileURICache = std::make_unique<TileURICache>();
+
+    ROCKY_TODO("When disk cache is implemented, disable it here as it violates the ToS");
+
+    ROCKY_TODO("Update attribution - it's included in the per-tile metadata, but we don't track which tiles are still visible and only have the data in a const function");
+
+    return StatusOK;
+}
+
+void
+BingImageLayer::closeImplementation()
+{
+    _tileURICache.reset();
+    super::closeImplementation();
+}
+
+Result<GeoImage>
+BingImageLayer::createImageImplementation(const TileKey& key, const IOOptions& io) const
+{
+    ROCKY_PROFILE_FUNCTION();
+
+    auto imageURI = _tileURICache->get(key);
+
+    if (!imageURI.has_value())
+    {
+        // Bing's zoom is indexed slightly differently
+        auto zoom = key.levelOfDetail() + 1;
+        GeoPoint centre = key.extent().centroid();
+        centre.transformInPlace(centre.srs.geoSRS());
+
+        std::stringstream relative;
+        relative << std::setprecision(12);
+        relative << "/" << imagerySet.value();
+        relative << "/" << centre.y << "," << centre.x;
+        relative << "?zl=" << zoom;
+        relative << "&o=json";
+        if (apiKey.has_value())
+            relative << "&key=" << apiKey.value();
+
+        URI metadataURI(imageryMetadataUrl->full() + relative.str(), imageryMetadataUrl->context());
+
+        auto metaFetch = metadataURI.read(io);
+        if (metaFetch.status.ok())
+        {
+            auto json = parse_json(metaFetch->data);
+            const auto& vintage = json["/resourceSets/0/resources/0/vintageEnd"_json_pointer];
+            const auto& jsonURI = json["/resourceSets/0/resources/0/imageUrl"_json_pointer];
+            if (!vintage.empty() && !jsonURI.empty())
+                imageURI = URI(jsonURI.get<std::string>(), imageryMetadataUrl->context());
+            else
+                imageURI = StatusError;
+        }
+        else
+        {
+            imageURI = metaFetch.status;
+        }
+
+        _tileURICache->put(key, imageURI);
+    }
+
+    if (imageURI->status.failed())
+        return imageURI->status;
+
+    auto fetch = imageURI->value.read(io);
+    if (fetch.status.failed())
+        return fetch.status;
+
+    std::istringstream buf(fetch->data);
+    auto image_rr = io.services.readImageFromStream(buf, fetch->contentType, io);
+
+    if (image_rr.status.failed())
+        return image_rr.status;
+
+    shared_ptr<Image> image = image_rr.value;
+
+    if (image)
+        return GeoImage(image, key.extent());
+    else
+        return StatusError;
+}
+
+#endif // ROCKY_HAS_BING

--- a/src/rocky/BingImageLayer.h
+++ b/src/rocky/BingImageLayer.h
@@ -1,0 +1,56 @@
+/**
+ * rocky c++
+ * Copyright 2023-2024 Pelican Mapping, Chris Djali
+ * MIT License
+ */
+#pragma once
+#include <rocky/Bing.h>
+#ifdef ROCKY_HAS_BING
+
+#include <rocky/ImageLayer.h>
+#include <rocky/LRUCache.h>
+#include <rocky/URI.h>
+
+namespace ROCKY_NAMESPACE
+{
+    /**
+     * Image layer reading from Microsoft's Bing Maps API
+     */
+    class ROCKY_EXPORT BingImageLayer : public Inherit<ImageLayer, BingImageLayer>, public Bing::ImageLayerOptions
+    {
+    public:
+        //! Construct an empty Bing layer
+        BingImageLayer();
+        BingImageLayer(const JSON&);
+
+        //! Destructor
+        virtual ~BingImageLayer() { }
+
+        //! serialize
+        JSON to_json() const override;
+
+    protected: // Layer
+
+        using TileURICache = util::LRUCache<TileKey, optional<Result<URI>>>;
+
+        Status openImplementation(const IOOptions& io) override;
+
+        void closeImplementation() override;
+
+        //! Creates a raster image for the given tile key
+        Result<GeoImage> createImageImplementation(const TileKey& key, const IOOptions& io) const override;
+
+        std::unique_ptr<TileURICache> _tileURICache;
+
+    private:
+
+        void construct(const JSON&);
+    };
+}
+
+
+#else // if !ROCKY_HAS_BING
+#ifndef ROCKY_BUILDING_SDK
+#error Bing support is not enabled in Rocky.
+#endif
+#endif // ROCKY_HAS_BING

--- a/src/rocky/Instance.cpp
+++ b/src/rocky/Instance.cpp
@@ -34,14 +34,18 @@ using namespace ROCKY_NAMESPACE;
 const Status& Instance::status() { return _global_status; }
 
 // static object factory map:
-std::unordered_map<std::string, Instance::ObjectFactory> Instance::objectFactories;
+std::unordered_map<std::string, Instance::ObjectFactory>& Instance::objectFactories()
+{
+    static std::unordered_map<std::string, Instance::ObjectFactory> factories;
+    return factories;
+}
 
 // static object creation function:
 shared_ptr<Object>
 Instance::createObjectImpl(const std::string& name, const JSON& conf)
 {
-    auto i = objectFactories.find(util::toLower(name));
-    if (i != objectFactories.end())
+    auto i = objectFactories().find(util::toLower(name));
+    if (i != objectFactories().end())
         return i->second(conf);
     return nullptr;
 }

--- a/src/rocky/Instance.h
+++ b/src/rocky/Instance.h
@@ -50,7 +50,7 @@ namespace ROCKY_NAMESPACE
 
         //! Global object factory map
         //! Use the ROCKY_ADD_OBJECT_FACTORY macro for bootstrap-time registration
-        static std::unordered_map<std::string, ObjectFactory> objectFactories;
+        static std::unordered_map<std::string, ObjectFactory>& objectFactories();
 
         //! Informational
         static std::set<std::string>& about();
@@ -80,7 +80,7 @@ namespace ROCKY_NAMESPACE
     #define ROCKY_ADD_OBJECT_FACTORY(NAME, FUNC) \
         struct __ROCKY_OBJECTFACTORY_##NAME##_INSTALLER { \
             __ROCKY_OBJECTFACTORY_##NAME##_INSTALLER () { \
-                ROCKY_NAMESPACE::Instance::objectFactories[util::toLower(#NAME)] = FUNC; \
+                ROCKY_NAMESPACE::Instance::objectFactories()[util::toLower(#NAME)] = FUNC; \
         } }; \
         __ROCKY_OBJECTFACTORY_##NAME##_INSTALLER __rocky_objectFactory_##NAME ;
 }

--- a/src/rocky/Profile.cpp
+++ b/src/rocky/Profile.cpp
@@ -99,7 +99,7 @@ Profile::operator == (const Profile& rhs) const
     if (_shared == rhs._shared)
         return true;
 
-    if (_shared->_wellKnownName == rhs._shared->_wellKnownName)
+    if (!_shared->_wellKnownName.empty() && _shared->_wellKnownName == rhs._shared->_wellKnownName)
         return true;
 
     return

--- a/src/rocky/Version.h.in
+++ b/src/rocky/Version.h.in
@@ -38,6 +38,8 @@
 #cmakedefine ROCKY_HAS_ZLIB
 #cmakedefine ROCKY_HAS_TMS
 #cmakedefine ROCKY_HAS_MBTILES
+#cmakedefine ROCKY_HAS_AZURE
+#cmakedefine ROCKY_HAS_BING
 
 #cmakedefine ROCKY_HAS_VSG
 #cmakedefine ROCKY_HAS_VSGXCHANGE


### PR DESCRIPTION
I've split this PR into four commits of varying controversy.

The first two are fixes, and fairly straightforward. Not having them will inevitably lead to problems with something else later as they're not specific to the Bing/Azure stuff.

The next one is the one that actually adds Bing and Azure support. The Azure part's straightforward as the tile interface is simple, but it doesn't support elevation and satellite and aerial photography isn't available in the free tier, so even though it's deprecated, I also added Bing support. The specifics of that take some inspiration from the equivalent in osgEarth, e.g. getting the specific tile URL via the metadata API and caching the URL, but again it's pretty straightforward.

The final commit might be clever, a hack, or both, but it helps a lot to avoid the API rate limiting with Bing Maps and to reduce the number of redundant fetches, while also avoiding #47 even if you *do* still manage to hit a limit. There's more of a description in the commit message but the gist is that it uses `weak_ptr`s to track which source images are still referenced, and a vector of `shared_ptr`s in tiles produced by `assembleImage` to ensure that the source tiles that make up the composite image are kept alive. I think it's fine for a temporary solution, but it might not be what ends up used forever.