### PR TITLE
Rate limit mitigation (and minor fixes)

### DIFF
--- a/src/rocky/BingImageLayer.cpp
+++ b/src/rocky/BingImageLayer.cpp
@@ -110,7 +110,7 @@ BingImageLayer::createImageImplementation(const TileKey& key, const IOOptions& i
             if (!vintage.empty() && !jsonURI.empty())
                 imageURI = URI(jsonURI.get<std::string>(), imageryMetadataUrl->context());
             else
-                imageURI = StatusError;
+                imageURI = Status(Status::ResourceUnavailable, "No data at this level");
         }
         else
         {


### PR DESCRIPTION
This is kind of three unrelated things, so sorry for lumping them into one pull request.

* An improved return value when Bing Maps has no data for a particular tilekey
* The fallback mechanism introduced in #41 meant that high-LOD tiles would get created even if they only had low-LOD data, so avoid doing that.
* Extend the retry system for HTTP requests to also happen for 429 Too Many Requests errors. There's more detail in the commit message. This puts a massive dent in the number of failed tiles when zoomed in with Bing Maps, so you can get roughly a whole extra zoom level or two before overwhelming the API.