### PR TITLE
Add builtin-baseline setting to vcpkg.json

### DIFF
--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -26,5 +26,6 @@
           "features": [ "assimp", "freetype" ] },
         "vsgqt",
         "zlib"
-    ]
+    ],
+    "builtin-baseline": "9558037875497b9db8cf38fcd7db68ec661bffe7"
 }


### PR DESCRIPTION
Newer versions of vcpkg require a builtin-baseline setting that specifies the minimum versions of all packages, as described here: https://learn.microsoft.com/en-us/vcpkg/users/versioning#baselines and here: https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json#builtin-baseline.  Without this setting, bootstrap-vcpkg.bat errors out with this message:

```
[...]
-- Running vcpkg install
error: this vcpkg instance requires a manifest with a specified baseline in order to interact with ports. Please add 'builtin-baseline' to the manifest or add a 'vcpkg-configuration.json' that redefines the default registry.
-- Running vcpkg install - failed
CMake Error at C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/vcpkg/scripts/buildsystems/vcpkg.cmake:899 (message):
  vcpkg install failed.  See logs for more information:
  C:\Projects\Worldscape\rocky\build\vcpkg-manifest-install.log
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:11 (project)

-- Configuring incomplete, errors occurred!
```

Because the existing manifest doesn't specify any versions, the new manifest should be equivalent for someone starting out and doing a clean build but will probably provoke package upgrades and rebuilds for existing dev environments, as the baseline will likely be newer than the package versions that are currently installed.