### PR TITLE
Fix engine app startup

### DIFF
--- a/src/apps/rocky_engine/rocky_engine.cpp
+++ b/src/apps/rocky_engine/rocky_engine.cpp
@@ -115,15 +115,11 @@ int main(int argc, char** argv)
     auto imagery = rocky::TMSImageLayer::create();
     imagery->uri = "https://readymap.org/readymap/tiles/1.0.0/7/";
     mapNode->map->layers().add(imagery);
-    if (imagery->status().failed())
-        return error(imagery);
 
     auto elevation = rocky::TMSElevationLayer::create();
     elevation->encoding = rocky::ElevationLayer::Encoding::MapboxRGB;
     elevation->uri = "https://readymap.org/readymap/tiles/1.0.0/116/";
     mapNode->map->layers().add(elevation);
-    if (elevation->status().failed())
-        return error(elevation);
 
 #else // if !ROCKY_HAS_TMS
 


### PR DESCRIPTION
The engine app currently adds two TMS layers and then immediately checks to make sure that their status isn't failed, but this causes the app to error out and not start up correctly.  Comparing the engine code to the demo app, it appears that the TMS layers are supposed to be loaded later in the startup process and so they're going to start out with the "layer closed" status.  Removing this check allows the engine app to start up and run correctly.

Without this fix, this is the output from the engine app (and then it exits):
```
[vsg info] texel_margin = 12
[vsg info] quad_margin = 6
[rocky info] Hello, world.
[rocky info] Welcome to rocky version 0.4.1
[rocky info] Using VSG 1.1.7 (so 14)
[rocky warning] Problem with layer "" : Layer closed
```