### PR TITLE
rocky_demo_qt: Update to vsgQt 0.3.0+ API

### DIFF
--- a/src/apps/rocky_demo_qt/rocky_demo_qt.cpp
+++ b/src/apps/rocky_demo_qt/rocky_demo_qt.cpp
@@ -39,7 +39,7 @@ int layerError(T layer)
 class MyQtViewer : public vsg::Inherit<vsgQt::Viewer, MyQtViewer>
 {
 public:
-    void render() override
+    void render(double simulationTime) override
     {
         if (continuousUpdate || requests.load() > 0)
         {


### PR DESCRIPTION
Add simulation time parameter, so that the code compiles against vsgQt 0.4.0. This parameter was added in version 0.3.0.