### PR TITLE
Tests: Fix JSON header error by depending on nlohmann_json

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,6 +6,15 @@ add_executable(${APP_NAME} ${SOURCES})
 
 target_link_libraries(${APP_NAME} rocky)
 
+# Tests use json.h, which relies on nlohmann_json, which is not a public dependency of rocky
+if (BUILD_WITH_JSON)
+    find_package(nlohmann_json CONFIG)
+    if (nlohmann_json_FOUND)
+        target_link_libraries(${APP_NAME} nlohmann_json::nlohmann_json)
+    endif()
+endif()
+
+
 install(TARGETS ${APP_NAME} RUNTIME DESTINATION bin)
 
 set_target_properties(${APP_NAME} PROPERTIES FOLDER "tests")


### PR DESCRIPTION
The tests include `rocky/json.h`, which in turn includes `nlohmann/json.hpp`. This is a private depedency of Rocky, so this include statement is not transitive. It fails to build. vcpkg builds do not see this because the vcpkg install directory is part of the include path, and this file is under it.

One solution is to make the JSON dependency public in Rocky, but header docs strongly suggest this is not the right path. A better path is to make the test add in the JSON dependency.

The `find_package` is required because the library is scoped to the `src/rocky/` directory.