### PR TITLE
CMake: SQLite3 package now falls back to official CMake SQLite search if vcpkg is not found

### DIFF
--- a/src/rocky/CMakeLists.txt
+++ b/src/rocky/CMakeLists.txt
@@ -79,9 +79,15 @@ if(BUILD_WITH_CURL)
 endif()
 
 # sqlite3 - database - required to support some formats like mbtiles
-if (BUILD_WITH_SQLITE3)
-    find_package(unofficial-sqlite3 CONFIG REQUIRED)
-    if (unofficial-sqlite3_FOUND)
+if(BUILD_WITH_SQLITE3)
+    find_package(unofficial-sqlite3 CONFIG QUIET)
+    if(NOT unofficial-sqlite3_FOUND)
+        # vcpkg SQLite not found; fall back to CMake find_package
+        find_package(SQLite3 REQUIRED)
+        set(unofficial-sqlite3_FOUND TRUE)
+        add_library(unofficial::sqlite3::sqlite3 ALIAS SQLite::SQLite3)
+    endif()
+    if(unofficial-sqlite3_FOUND)
         set(ROCKY_HAS_SQLITE TRUE)
     endif()
 endif()


### PR DESCRIPTION
I am attempting to build without vcpkg, which looks like is expected to be supported. Going well so far, but SQLite is posing a problem. There's no find_package for `unofficial-sqlite3` that I can find outside of vcpkg, which forces you to go down vcpkg for this dependency.

Instead, vcpkg is now attempted first, and if not found the official CMake SQLite search is used (and correctly fails if not found due to the `REQUIRED` flag). An alias library is created in order to maintain compatibility.