### PR TITLE
CMake Install: Fix extra/missing packages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,11 +16,6 @@ endfunction()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-# For windows import/export
-if(NOT ROCKY_BUILD_SHARED_LIBS)
-    add_definitions(-DROCKY_STATIC)
-endif()
-
 add_subdirectory(rocky)
 add_subdirectory(apps)
 add_subdirectory(tests)

--- a/src/rocky/CMakeLists.txt
+++ b/src/rocky/CMakeLists.txt
@@ -222,6 +222,11 @@ add_library(rocky ${BUILD_TYPE}
     ${SHADERS_VSG}
 )
 
+# For windows import/export
+if(NOT ROCKY_BUILD_SHARED_LIBS)
+    target_compile_definitions(rocky PUBLIC ROCKY_STATIC)
+endif()
+
 if(ROCKY_APPEND_SO_VERSION)
     set_target_properties(rocky PROPERTIES VERSION ${PROJECT_VERSION_ABI} SOVERSION ${PROJECT_VERSION_ABI})
 endif()

--- a/src/rocky/rocky-config.cmake.in
+++ b/src/rocky/rocky-config.cmake.in
@@ -10,28 +10,34 @@ if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
-set (ROCKY_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
-set (ROCKY_SHARE_DIR "${PACKAGE_PREFIX_DIR}/share/rocky")
-set_and_check (ROCKY_BUILD_DIR "${PACKAGE_PREFIX_DIR}")
+set(ROCKY_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
+set(ROCKY_SHARE_DIR "${PACKAGE_PREFIX_DIR}/share/rocky")
+set_and_check(ROCKY_BUILD_DIR "${PACKAGE_PREFIX_DIR}")
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(PROJ CONFIG REQUIRED)
-find_dependency(glm CONFIG REQUIRED)
-find_dependency(spdlog CONFIG REQUIRED)
+# Find public dependencies
+find_dependency(glm CONFIG)
+find_dependency(spdlog CONFIG)
+find_dependency(entt CONFIG)
+find_dependency(vsg CONFIG)
 
-find_dependency(entt CONFIG REQUIRED)
-find_dependency(vsg CONFIG REQUIRED)
-find_dependency(vsgXchange CONFIG REQUIRED)
-
-if(@ROCKY_HAS_GDAL@)
-    find_dependency(GDAL CONFIG REQUIRED)
+# Find private dependencies, for linking to static library
+if(NOT @ROCKY_BUILD_SHARED_LIBS@)
+    find_dependency(PROJ CONFIG)
+    if(@ROCKY_HAS_VSGXCHANGE@)
+        find_dependency(vsgXchange CONFIG)
+    endif()
+    if(@ROCKY_HAS_GDAL@)
+        find_dependency(GDAL CONFIG)
+    endif()
+    if(@ROCKY_HAS_JSON@)
+        find_dependency(nlohmann_json CONFIG)
+    endif()
 endif()
 
-
-
-if (NOT TARGET "rocky")
-  include ("${CMAKE_CURRENT_LIST_DIR}/rocky-targets.cmake")
-endif ()
+if(NOT TARGET "rocky")
+  include("${CMAKE_CURRENT_LIST_DIR}/rocky-targets.cmake")
+endif()
 
 set(ROCKY_FOUND TRUE)


### PR DESCRIPTION
Clean-up pass on the CMake install. I noticed when integrating Rocky into my own project that the number of projects being searched for didn't seem right. I did a deep dive to clean this up:

* Setting the ROCKY_STATIC variable on the Rocky library instead of global, so that when you do a make install it carries over to the imported target correctly.
* Spacing normalization on open parens, to match rest of the file
* Anything public, now gets an unconditional `find_dependency` because it will show up in the link libs of the imported rocky target
* Anything private does not require a `find_dependency`, unless you're building static. If building static, now searching also for `nlohmann_json`.
* Now respecting various `ROCKY_HAS_` flags in the Config.cmake.in file, matching GDAL style
* Removed the `REQUIRED` flag on all `find_dependency`. Each one is implicitly required in order to get Rocky linking as an imported target. Adding `REQUIRED` causes early exits for `find_package(Rocky)` in cases where `find_package()` should be handling already in a normalized way.

Side note, the CMake configuration for the project is awesome, it has been very easy to work with compared to some of the libraries we use. Having find_package "just work" is really useful.

I tested this on Windows MSVC 2022 with a standalone project importing Rocky and linking it to an executable. Rocky was built not using vcpkg. I did not yet test Linux, still working on getting all the dependencies built there but I'd expect this to work identically there.