### PR TITLE
Linux: gcc 13.x fixes

### DIFF
--- a/src/rocky/Common.h
+++ b/src/rocky/Common.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <iostream>
 #include <cstdlib>
+#include <cstdint>
 
 // match the weejobs export to the library export
 #ifndef WEEJOBS_EXPORT

--- a/src/rocky/rocky-config.cmake.in
+++ b/src/rocky/rocky-config.cmake.in
@@ -19,7 +19,7 @@ include(CMakeFindDependencyMacro)
 # Find public dependencies
 find_dependency(glm CONFIG)
 find_dependency(spdlog CONFIG)
-find_dependency(entt CONFIG)
+find_dependency(EnTT CONFIG)
 find_dependency(vsg CONFIG)
 
 # Find private dependencies, for linking to static library

--- a/src/rocky/vsg/ecs/ECSNode.h
+++ b/src/rocky/vsg/ecs/ECSNode.h
@@ -131,14 +131,14 @@ namespace ROCKY_NAMESPACE
 
         public:
             //! Destructor
-            virtual ~SystemNode<T>();
+            virtual ~SystemNode();
 
             // looks for any new components that need VSG initialization
             void update(VSGContext&) override;
 
         protected:
             //! Construct from a subclass
-            SystemNode<T>(Registry& in_registry);
+            SystemNode(Registry& in_registry);
 
             //! Feature mask for a specific component instance
             virtual int featureMask(const T& t) const { return 0; }


### PR DESCRIPTION
Minor fixes to get Rocky building on gcc 13 systems:
* Capitalization fix for `find_dependency(EnTT)` that matters on Linux
* Removed excess template tag, gcc13 does not like
* Missing cstdint for size-specific int types

Tested on both Windows and Linux.