### PR TITLE
Demo_Stats: Fix gcc 14 build issue with mismatched types on min()

### DIFF
--- a/src/apps/rocky_demo/Demo_Stats.h
+++ b/src/apps/rocky_demo/Demo_Stats.h
@@ -43,7 +43,7 @@ namespace
         long long result = INT_MAX;
         int s = start - count; if (s < 0) s += frame_count;
         for (int i = s; i <= s + count; i++)
-            result = std::min(result, t[i % frame_count].count());
+            result = std::min(result, static_cast<long long>(t[i % frame_count].count()));
         return result;
     }
 }


### PR DESCRIPTION
Linux gcc did not like to build without this being typecast to the same unit type as `result`.