### PR TITLE
Fixed several build errors which would occur when `ROCKY_HAS_IMGUI` was _not_ defined.

### DIFF
--- a/src/rocky/vsg/Application.cpp
+++ b/src/rocky/vsg/Application.cpp
@@ -28,10 +28,6 @@
 #include <vsg/io/read.h>
 #include <vsg/core/Version.h>
 
-#ifdef ROCKY_HAS_IMGUI
-
-#endif
-
 using namespace ROCKY_NAMESPACE;
 
 namespace

--- a/src/rocky/vsg/DisplayManager.cpp
+++ b/src/rocky/vsg/DisplayManager.cpp
@@ -7,7 +7,10 @@
 #include "Application.h"
 #include "MapManipulator.h"
 #include "terrain/TerrainEngine.h"
+
+#ifdef ROCKY_HAS_IMGUI
 #include "imgui/ImGuiIntegration.h"
+#endif
 
 using namespace ROCKY_NAMESPACE;
 

--- a/src/rocky/vsg/ecs/Widget.h
+++ b/src/rocky/vsg/ecs/Widget.h
@@ -9,17 +9,18 @@
 
 #ifdef ROCKY_HAS_IMGUI
 #include <imgui.h>
+#else
+namespace ROCKY_NAMESPACE
+{
+  struct ImVec2 { float x; float y; };
+  using ImGuiContext = void;
+}
 #endif
 
 namespace ROCKY_NAMESPACE
 {
-#ifdef ROCKY_HAS_IMGUI
     using WidgetVec2 = ImVec2;
     using WidgetContext = ImGuiContext;
-#else
-    struct ImVec2 { float x; float y; };
-    using ImGuiContext = void;
-#endif
 
     struct WidgetInstance
     {

--- a/src/rocky/vsg/ecs/WidgetSystem.h
+++ b/src/rocky/vsg/ecs/WidgetSystem.h
@@ -4,6 +4,8 @@
  * MIT License
  */
 #pragma once
+
+#ifdef ROCKY_HAS_IMGUI
 #include <rocky/vsg/ecs/Widget.h>
 #include <rocky/vsg/ecs/Registry.h>
 
@@ -26,3 +28,4 @@ namespace ROCKY_NAMESPACE
         void update(VSGContext& context) override;
     };
 }
+#endif // defined(ROCKY_HAS_IMGUI)


### PR DESCRIPTION
The `README.md` file for Rocky claims that Dear ImGui is an "optional" requirement. Yet, upon attempting to build Rocky without it, several build failures were encountered. The intent is for the `ROCKY_HAS_IMGUI` macro to be used in order to determine at compile time whether Dear ImGui-specific functionality should be included in Rocky. However, it appears as though this macro was not being used correctly in all places.

This commit makes some necessary adjustments in order to get Rocky to _build_ without Dear ImGui. It should be noted that I have not actually tested these changes outside of ensuring that the build succeeds on my system; it may be the case that several other issues exist which have yet to be diagnosed.