### PR TITLE
Fix washed-out colours of mosaicked image data

### DIFF
--- a/src/rocky/ImageLayer.cpp
+++ b/src/rocky/ImageLayer.cpp
@@ -311,7 +311,7 @@ ImageLayer::assembleImage(const TileKey& key, const IOOptions& io) const
             SRSOperation xform = key.extent().srs().to(sources[0].srs());
 
             // new output:
-            output = Mosaic::create(Image::R8G8B8A8_UNORM, cols, rows, layers);
+            output = Mosaic::create(sources[0].image()->pixelFormat(), cols, rows, layers);
 
             // Cache pointers to the source images that mosaic to create this tile.
             output->dependencies.reserve(sources.size());


### PR DESCRIPTION
Without this PR, when viewing a map with a different profile to its source layer, pixels would be copied from a probably-sRGB image into a UNORM8 image, so the GPU wouldn't know it needed to convert the values to linear space before using them for lighting, and they'd appear washed-out. With this PR, it's no longer copied without proper conversion.

Just adding the correct conversions to `Image.cpp` makes things much better as everything ends up much closer to the correct value, but unconditionally using UNORM8 as the format for the mosaic image would crush out dark tones and produce banding as eight bits aren't enough without perceptual quantisation like sRGB.

To address that, the mosaic is now created with the same format as (one tile of) its source data. Because of the fixed conversions, it's not a big deal if the source data has mixed formats.

I suspect there are other colour space issues in Rocky as I've not seen anything to handle elevation data incorrectly identifying itself as sRGB.