### PR TITLE
rocky_demo: Fix reference, to const reference

### DIFF
--- a/src/apps/rocky_demo/rocky_demo.cpp
+++ b/src/apps/rocky_demo/rocky_demo.cpp
@@ -148,8 +148,8 @@ struct MainGUI : public vsg::Inherit<ImGuiNode, MainGUI>
         if (!attribution.has_value())
         {
             std::string buf;
-            auto& layers = app.mapNode->map->layers().all();
-            for (auto& layer : layers) {
+            const auto& layers = app.mapNode->map->layers().all();
+            for (const auto& layer : layers) {
                 if (layer->status().ok() && layer->attribution.has_value()) {
                     if (!buf.empty())
                         buf += ", ";


### PR DESCRIPTION
gcc is flagging this as an error:

```
/usr/people/github/rocky/src/apps/rocky_demo/rocky_demo.cpp: In member function ‘void MainGUI::renderAttribution() const’:
/usr/people/github/rocky/src/apps/rocky_demo/rocky_demo.cpp:151:58: error: cannot bind non-const lvalue reference of type ‘std::vector<std::shared_ptr<rocky::Layer> >&’ to an rvalue of type ‘std::vector<std::shared_ptr<rocky::Layer> >’
  151 |             auto& layers = app.mapNode->map->layers().all();
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```