### PR TITLE
ECSNode: Const reference to fix gcc compile error.

### DIFF
--- a/src/rocky/vsg/ecs/ECSNode.h
+++ b/src/rocky/vsg/ecs/ECSNode.h
@@ -449,7 +449,7 @@ namespace ROCKY_NAMESPACE
             
 
         // Get an optimized view of all this system's components:
-        auto& view = registry.view<T, ActiveState, Visibility>();
+        const auto& view = registry.view<T, ActiveState, Visibility>();
         view.each([&](const entt::entity entity, auto& component, auto& active, auto& visibility)
             {
                 auto& renderable = registry.get<Renderable>(component.attach_point);


### PR DESCRIPTION
Should fix compile error under gcc 14.2.1.