### PR TITLE
DisplayManager: Correctly forward declare Application.

### DIFF
--- a/src/rocky/vsg/DisplayManager.h
+++ b/src/rocky/vsg/DisplayManager.h
@@ -13,6 +13,7 @@
 
 namespace ROCKY_NAMESPACE
 {
+    class Application;
     class ImGuiContextGroup;
 
     //! Return value for pointAtWindowCoords(viewer) method


### PR DESCRIPTION
Fixes a compile error on Linux. Does not seem to cause issues on Windows MSVC.