### PR TITLE
include IMGUI publicly to address build error on linux due to missing…

### DIFF
--- a/src/rocky/CMakeLists.txt
+++ b/src/rocky/CMakeLists.txt
@@ -168,7 +168,7 @@ if(unofficial-sqlite3_FOUND AND ZLIB_FOUND)
 endif()
 
 if(ImGui_FOUND)
-    list(APPEND PRIVATE_LIBS imgui::imgui)
+    list(APPEND PUBLIC_LIBS imgui::imgui)
 endif()
 
 if (ROCKY_SUPPORTS_AZURE)


### PR DESCRIPTION
… <imgui.h>

happy monday. Our nightly linux builder has an issue with https://github.com/pelicanmapping/rocky/commit/1fb0c54660422ddd72303d43d825c92da5f60646 due to the header change in `src/rocky/vsg/ecs/WidgetSystem.h`.

I'm by no means a CMake expert, but this change fixes the build error on linux on our side. There certainly might be a cleaner way to do this.

If you prefer, I did find that changing the imgui.h include in `src/rocky/vsg/ecs/WidgetSystem.h` from `#include <imgui.h>` to `#include "imgui.h"` also fixed the issue.