### PR TITLE
rocky_demo_qt: Support Qt6 and Qt5

### DIFF
--- a/src/apps/rocky_demo_qt/CMakeLists.txt
+++ b/src/apps/rocky_demo_qt/CMakeLists.txt
@@ -6,20 +6,13 @@ find_package(vsgQt CONFIG REQUIRED)
 
 # Find Qt, if vsgQt didn't already find it
 if(NOT TARGET Qt::Widgets)
-    find_package(Qt6 QUIET COMPONENTS Widgets CONFIG)
-    if(Qt6_FOUND)
-        message(STATUS "Found Qt6: ${Qt6_DIR}")
-    else()
-        find_package(Qt5 QUIET COMPONENTS Widgets CONFIG)
-        if(Qt5_FOUND)
-            message(STATUS "Found Qt5: ${Qt5_DIR}")
-            include_directories(${Qt5_DIR}/qt5)
-        else()
-            # Provide a warning if neither is found, but don't stop the configuration.
-            message(WARNING "Neither Qt5 nor Qt6 was found. rocky_demo_qt will not build.")
-            return()
-        endif()
+    # Figure out what version of Qt vsgQt linked against by inspecting dependencies. Match vsgQt.
+    get_target_property(_VSGQT_INTERFACE_LINK_LIBRARIES vsgQt::vsgQt INTERFACE_LINK_LIBRARIES)
+    set(_ROCKY_QT_VERSION 6)
+    if("${_VSGQT_INTERFACE_LINK_LIBRARIES}" MATCHES "Qt5::")
+        set(_ROCKY_QT_VERSION 5)
     endif()
+    find_package(Qt${_ROCKY_QT_VERSION} REQUIRED COMPONENTS Widgets CONFIG)
 endif()
 
 file(GLOB SOURCES *.cpp)


### PR DESCRIPTION
Several minor changes to support Qt6 and Qt5:

* Removed `if(vsgQt_FOUND)` and reduced scope -- it's impossible for this to fail due to `REQUIRED` on the `find_package`
* Reorder `find_package` just to simplify, before Qt checks
* Don't search for Qt at all, if `Qt::Widgets` exists. This is a future compatibility thing. `vsgQt` for transitivity ought to search for Qt. It does so apparently with vcpkg, but not a standalone build.
* Search for Qt version based on whether vsgQt links to Qt5 or Qt6.

I tested by building and running both in Qt5 and Qt6 modes, by adding one or the other to my `CMAKE_PREFIX_PATH` before CMake configure/generate. Testing was on Windows MSVC, but I expect Linux to behave similarly. I did not test vcpkg configuration, and I expect vcpkg to skip the find_package() due to having Qt::Widgets already defined by vsgQt's `find_dependency()`.