### PR TITLE
fix: to match VSG renamed maxNumMipmaps to mipLevels

### DIFF
--- a/src/rocky/vsg/VSGUtils.h
+++ b/src/rocky/vsg/VSGUtils.h
@@ -242,7 +242,11 @@ namespace ROCKY_NAMESPACE
 
             auto data = wrapImageData(image);
             data->properties.origin = vsg::TOP_LEFT;
+#if VSG_API_VERSION_LESS(1,1,12)
+            data->properties.maxNumMipmaps = 1;
+#else
             data->properties.mipLevels = 1;
+#endif
 
             return data;
         }
@@ -341,7 +345,11 @@ namespace ROCKY_NAMESPACE
 
             auto data = moveImageData(image);
             data->properties.origin = vsg::TOP_LEFT;
+#if VSG_API_VERSION_LESS(1,1,12)
+            data->properties.maxNumMipmaps = 1;
+#else
             data->properties.mipLevels = 1;
+#endif
 
             return data;
         }


### PR DESCRIPTION
To match VSG commit: [Renamed Properties.maxNumMipMaps to Properties.mipLevels to be consistent with Vulkan naming.](https://github.com/vsg-dev/VulkanSceneGraph/commit/856cd2ab84e659e20443a8363469eb59f8f113b2)
