### PR TITLE
rocky_demo: Use /bigobj on MSVC Debug Mode

### DIFF
--- a/src/apps/rocky_demo/CMakeLists.txt
+++ b/src/apps/rocky_demo/CMakeLists.txt
@@ -17,3 +17,8 @@ target_link_libraries(${APP_NAME} rocky imgui::imgui)
 install(TARGETS ${APP_NAME} RUNTIME DESTINATION bin)
 
 set_target_properties(${APP_NAME} PROPERTIES FOLDER "apps")
+
+# MSVC requires /bigobj on debug mode
+if(MSVC)
+    target_compile_options(${APP_NAME} PRIVATE "$<$<CONFIG:Debug>:/bigobj>")
+endif()


### PR DESCRIPTION
Debug builds started to error out with:

```
...rocky\src\apps\rocky_demo\rocky_demo.cpp(1,1): error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

This fixes that error. osgEarth has something similar but at a higher scope. Debug builds are required on Windows in order to link to anything else that uses `/MDd` compile flags.