### PR TITLE
Fixed issues identified by Valgrind and cppCheck

### DIFF
--- a/src/rocky/Ellipsoid.cpp
+++ b/src/rocky/Ellipsoid.cpp
@@ -335,7 +335,7 @@ Ellipsoid::calculateHorizonPoint(const std::vector<glm::dvec3>& points) const
 {
     double max_magnitude = 0.0;
 
-    glm::dvec3 unit_culling_point_dir; // vector along which to calculate the horizon point
+    glm::dvec3 unit_culling_point_dir(0.0, 0.0, 0.0); // vector along which to calculate the horizon point
     std::vector<glm::dvec3> unit_points;
     unit_points.reserve(points.size());
     for (auto& point : points)
@@ -348,6 +348,11 @@ Ellipsoid::calculateHorizonPoint(const std::vector<glm::dvec3>& points) const
     for (auto& unit_point : unit_points)
     {
         auto mag2 = glm::dot(unit_point, unit_point); // length squared
+
+        // prevent division by zero
+        if (mag2 < 1e-12)
+          continue;
+
         auto mag = sqrt(mag2);
         auto point_dir = unit_point / mag;
 

--- a/src/rocky/Horizon.h
+++ b/src/rocky/Horizon.h
@@ -61,9 +61,9 @@ namespace ROCKY_NAMESPACE
         Ellipsoid _em;
         bool _valid = false;
         bool _orthographic = false; // assume orthographic projection
-        glm::dvec3 _eye;       // world eyepoint
-        glm::dvec3 _eyeUnit;   // unit eye vector (scaled)
-        glm::dvec3 _VC;        // eye->center vector (scaled)
+        glm::dvec3 _eye = {0.0, 0.0, 0.0};       // world eyepoint
+        glm::dvec3 _eyeUnit = { 0.0, 0.0, 0.0 };   // unit eye vector (scaled)
+        glm::dvec3 _VC = { 0.0, 0.0, 0.0 };        // eye->center vector (scaled)
         double _VCmag = 0.0;    // distance from eye to center (scaled)
         double _VCmag2 = 0.0;   // distance from eye to center squared (scaled)
         double _VHmag2 = 0.0;   // distance from eye to horizon squared (scaled)

--- a/src/rocky/vsg/MapManipulator.cpp
+++ b/src/rocky/vsg/MapManipulator.cpp
@@ -2014,7 +2014,7 @@ MapManipulator::ndc(const vsg::PointerEvent& event) const
 {
     auto camera = _camera_weakptr.ref_ptr();
     if (!camera)
-        false;
+        return {0.0, 0.0};
 
     auto renderArea = camera->getRenderArea();
 

--- a/src/rocky/vsg/ecs/PointSystem.h
+++ b/src/rocky/vsg/ecs/PointSystem.h
@@ -145,7 +145,7 @@ namespace ROCKY_NAMESPACE
     private:
         mutable detail::PointStyleDetail _defaultStyleDetail;
         mutable vsg::ref_ptr<vsg::MatrixTransform> _tempMT;
-        mutable float _devicePixelRatio;
+        mutable float _devicePixelRatio = -1.0;
 
         inline vsg::PipelineLayout* getPipelineLayout(const Point&) {
             return _pipelines[0].config->layout;


### PR DESCRIPTION
The glm::dvec3 constructor does not initialize member variables.
Prevent division by zero.
Fixed return value for MapManipulator::ndc routine.
Initialized PointSystem::_devicePixelRatio to -1.0 to make sure PointSystemNode::update executes.