### PR TITLE
Static init: GeoCircle::INVALID, GeoExtent::INVALID, and GeoPoint::INVALID replaced with static invalid() functions the have a defined initialization order.

### DIFF
--- a/src/rocky/GeoCircle.cpp
+++ b/src/rocky/GeoCircle.cpp
@@ -8,11 +8,9 @@ using namespace ROCKY_NAMESPACE;
 #undef EPSILON
 #define EPSILON 1e-6
 
-GeoCircle GeoCircle::INVALID = GeoCircle();
-
 
 GeoCircle::GeoCircle() :
-    _center(GeoPoint::INVALID),
+    _center(GeoPoint::invalid()),
     _radius(-1.0)
 {
     //nop
@@ -74,4 +72,11 @@ GeoCircle::intersects( const GeoCircle& rhs ) const
             return p0.geodesicDistanceTo(p1) <= Distance(radius() + rhs.radius());
         }
     }
+}
+
+const GeoCircle&
+GeoCircle::invalid()
+{
+    static GeoCircle instance(GeoPoint::invalid(), -1.0);
+    return instance;
 }

--- a/src/rocky/GeoCircle.h
+++ b/src/rocky/GeoCircle.h
@@ -54,7 +54,8 @@ namespace ROCKY_NAMESPACE
 
      public:
 
-         static GeoCircle INVALID;
+         /** Represents an invalid, uninitialized circle */
+         static const GeoCircle& invalid();
 
      protected:
          GeoPoint _center;

--- a/src/rocky/GeoExtent.cpp
+++ b/src/rocky/GeoExtent.cpp
@@ -26,8 +26,6 @@ namespace {
     }
 }
 
-GeoExtent GeoExtent::INVALID = GeoExtent();
-
 
 GeoExtent::GeoExtent() :
     _west(0.0),
@@ -126,7 +124,7 @@ GeoExtent::centroid() const
             normalizeX(west() + 0.5 * width()),
             south() + 0.5 * height());
     }
-    else return GeoPoint::INVALID;
+    else return GeoPoint::invalid();
 }
 
 bool
@@ -232,7 +230,7 @@ GeoExtent::transform(const SRS& to_srs) const
 {
     // check for NULL
     if (!valid() || !to_srs.valid())
-        return GeoExtent::INVALID;
+        return GeoExtent::invalid();
 
     if (to_srs.isGeocentric())
         return transform(to_srs.geodeticSRS());
@@ -557,20 +555,20 @@ GeoExtent::intersectionSameSRS(const GeoExtent& rhs) const
 {
     if (!valid() || !rhs.valid())
     {
-        return GeoExtent::INVALID;
+        return GeoExtent::invalid();
     }
 
     // check for basic intersection. Note, we do NOT validate
     // that they are the same SRS!
     if (!intersects(rhs))
     {
-        return GeoExtent::INVALID;
+        return GeoExtent::invalid();
     }
 
     // first check Y.
     if (ymin() > rhs.ymax() || ymax() < rhs.ymin())
     {
-        return GeoExtent::INVALID; // they don't overlap in Y.
+        return GeoExtent::invalid(); // they don't overlap in Y.
     }
 
     GeoExtent result(*this);
@@ -883,6 +881,13 @@ GeoExtent::createScaleBias(const GeoExtent& rhs, glm::dmat4& output) const
     output[3][1] = biasy;  // [1][3]?
 
     return true;
+}
+
+const GeoExtent&
+GeoExtent::invalid()
+{
+    static GeoExtent instance;
+    return instance;
 }
 
 

--- a/src/rocky/GeoExtent.h
+++ b/src/rocky/GeoExtent.h
@@ -177,7 +177,7 @@ namespace ROCKY_NAMESPACE
         inline void clamp(ITER begin, ITER end) const;
 
     public:
-        static GeoExtent INVALID;
+        static const GeoExtent& invalid();
 
     private:
         double _west, _width, _south, _height;

--- a/src/rocky/GeoImage.cpp
+++ b/src/rocky/GeoImage.cpp
@@ -21,7 +21,7 @@ using namespace ROCKY_NAMESPACE;
 
 GeoImage::GeoImage() :
     _image(nullptr),
-    _extent(GeoExtent::INVALID)
+    _extent(GeoExtent::invalid())
 {
     //nop
 }
@@ -35,7 +35,7 @@ GeoImage::operator=(GeoImage&& rhs) noexcept
         _extent = std::move(rhs._extent);
     }
     rhs._image = nullptr;
-    rhs._extent = GeoExtent::INVALID;
+    rhs._extent = GeoExtent::invalid();
     return *this;
 }
 

--- a/src/rocky/GeoPoint.cpp
+++ b/src/rocky/GeoPoint.cpp
@@ -8,8 +8,6 @@ using namespace ROCKY_NAMESPACE::detail;
 #undef  LC
 #define LC "[GeoPoint] "
 
-GeoPoint GeoPoint::INVALID;
-
 GeoPoint::GeoPoint()
 {
     //nop
@@ -104,6 +102,13 @@ std::string
 GeoPoint::string() const
 {
     return std::to_string(x) + ", " + std::to_string(y) + ", " + std::to_string(z) + " (" + srs.definition() + ")";
+}
+
+const GeoPoint&
+GeoPoint::invalid()
+{
+    static GeoPoint instance;
+    return instance;
 }
 
 #include "json.h"

--- a/src/rocky/GeoPoint.h
+++ b/src/rocky/GeoPoint.h
@@ -85,7 +85,7 @@ namespace ROCKY_NAMESPACE
         inline std::pair<SRSOperation, glm::dvec3> parseAsReferencePoint() const;
 
     public:
-        static GeoPoint INVALID;
+        static const GeoPoint& invalid();
 
         // copy/move ops
         GeoPoint(const GeoPoint& rhs) = default;

--- a/src/rocky/TileKey.cpp
+++ b/src/rocky/TileKey.cpp
@@ -46,7 +46,7 @@ GeoExtent
 TileKey::extent() const
 {
     if (!valid())
-        return GeoExtent::INVALID;
+        return GeoExtent::invalid();
 
     auto[width, height] = profile.tileDimensions(level);
     double xmin = profile.extent().xmin() + (width * (double)x);


### PR DESCRIPTION
Intended to fix static initialization order, especially with GeoPoint::INVALID and GeoExtent::INVALID. GeoExtent on Linux gcc15 is being initialized prior to GeoPoint, so the GeoPoint::INVALID is not yet defined at the time of use. The use of static method initialization ensures that the values initialize in a well behavior manner instead.

The rest of the fixes are simply intended to address the updated API.

Without this, gcc15 applications that link to Rocky crash on start-up with symbol resolution inside GeoExtent constructor, as it is initializing GeoExtent::INVALID and referencing the not-yet-created GeoPoint::INVALID.